### PR TITLE
Improve argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,24 +47,32 @@ Experiments can be launched by calling `commander.py` and a set of input argumen
 
 Here is a typical launch command and some comments:
 
-* `python commander.py --dataset ecg --name ecg_resnet1d_10_optadam_lr1e-3_lrReducePlateau0.5_bsz128 --epochs 20 --num-classes 5 --root-dir ecg_data --arch resnet1d --model-name resnet1d_10 --batch-size 128 --lr 0.001 --scheduler ReduceLROnPlateau --optimizer adam --lr-decay 0.5 --step 15 --workers 4 --tensorboard --sampler equal` 
+* `python commander.py --dataset ecg --epochs 20 --num-classes 5 --root-dir ecg_data  --model-name resnet1d_10 --batch-size 128 --lr 0.001 --scheduler ReduceLROnPlateau --optimizer adam --lr-decay 0.5 --step 15 --workers 4 --tensorboard --sampler equal --version-bump` 
   + this experiment is on the _ecg_ dataset which can be found in `--root-dir/ecg` trained over _resnet1d_10_. It optimizes with _adam_ with initial learning rate ( `--lr` ) of `1e-3` which is decayed by half whenever the `--scheduler` _ReduceLRonPlateau_ does not see an improvement in the validation accuracy for more than `--step` epochs. Input sequences are of size 187. In addition it saves intermediate results to `--tensorboard` .
   + when debugging you can add the `--short-run` argument which performs training and validation epochs of 10 mini-batches. This allows testing your entire pipeline before launching an experiment
   + if you want to resume a previously paused experiment you can use the `--resume` flag which can continue the training from _best_, _latest_ or a specifically designated epoch.
   + if you want to use your model only for evaluation on the test set, add the `--test` flag. When doing this, ensure that the `--resume` flag is also being used (as well as the correct model name) otherwise testing will be done with an untrained model.
   + for unbalanced data sets the `--sampler` flag can be used to up-sample, alternatively `--class-balance` can be used to penalize errors in under-represented classes more. The two flags are mutually exclusive.
+  + to manage different runs of the same model, use `--version-latest` to run on the last run or `--version-bump` to create a new run.
 
 Here are some more typical launch commands:
 
-* `python commander.py --dataset ecg --name ecg_cnn1d_3_optadam_lr1e-3_lrReducePlateau0.5_bsz128 --epochs 20 --num-classes 5 --root-dir ecg_data --arch cnn1d --model-name cnn1d_3 --batch-size 128 --lr 0.001 --scheduler ReduceLROnPlateau --optimizer adam --tensorboard` 
+* `python commander.py --model-name cnn1d_3 --tensorboard --version-bump` 
 
-* `python commander.py --dataset ecg --name ecg_resnet1d_10_optadam_lr1e-3_lrReducePlateau0.5_bsz128 --epochs 20 --num-classes 5 --root-dir ecg_data --arch resnet1d --model-name resnet1d_10 --batch-size 128 --lr 0.001 --scheduler ReduceLROnPlateau --optimizer sgd --tensorboard` 
+* `python commander.py --model-name resnet1d_10 --tensorboard --version-bump` 
 
-* `python commander.py --dataset ecg --name ecg_resnet1d_v2_10_optadam_lr1e-3_lrReducePlateau0.5_bsz128_sample_eq --epochs 20 --num-classes 5 --root-dir ecg_data --arch resnet1d_v2 --model-name resnet1d_v2_10 --batch-size 128 --lr 0.001 --scheduler ReduceLROnPlateau --optimizer adam --tensorboard --sampler equal` 
+* `python commander.py --model-name resnet1d_v2 --tensorboard --version-bump` 
 
 To compute results on the testing run:
 
-* `python commander.py --dataset ecg --name ecg_cnn1d_3_optadam_lr1e-3_lrReducePlateau0.5_bsz128_testing --epochs 20 --num-classes 5 --root-dir ecg_data --arch cnn1d --model-name cnn1d_3 --batch-size 128 --lr 0.001 --scheduler ReduceLROnPlateau --optimizer adam --tensorboard --test --resume best` 
+* `python commander.py --model-name cnn1d_3 --tensorboard --test --resume best --version-latest` 
+
+or in the case of testing older models
+
+* `python commander.py --model-name cnn1d_3 --tensorboard --test --resume best --version 2` 
+
+
+
 
 ## Results
 

--- a/args.py
+++ b/args.py
@@ -34,7 +34,6 @@ def parse_args():
 
     # data settings
     parser.add_argument('--num-classes', default=0, type=int)
-    parser.add_argument('--input-channels', default=1, type=int)
     # number of workers for the dataloader
     parser.add_argument('-j', '--workers', type=int, default=1)
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -8,36 +8,16 @@ from models.lstm import lstm
 
 
 def get_model(args):
-    model_instance = _get_model_instance(args.arch)
+    arch = get_arch_from_model(args.model_name)
+    print('Fetching model %s - %s ' % (arch, args.model_name))
 
-    print('Fetching model %s - %s ' % (args.arch, args.model_name))
-    if args.arch == 'resnet':
-        model = model_instance(
-            args.model_name, args.num_classes, args.input_channels, args.pretrained)
-    elif args.arch == 'squeezenet':
-        model = model_instance(
-            args.model_name, args.num_classes, args.input_channels, args.pretrained)
-    elif args.arch == 'lenet':
-        model = model_instance(
-            args.model_name, args.num_classes, args.input_channels)
-    elif args.arch == 'cnn1d':
-        model = model_instance(
-            args.model_name, args.num_classes, args.input_channels)
-    elif args.arch == 'resnet1d':
-        model = model_instance(
-            args.model_name, args.num_classes, args.input_channels)
-    elif args.arch == 'resnet1d_v2':
-        model = model_instance(
-            args.model_name, args.num_classes, args.input_channels)
-    elif args.arch == 'lstm':
-        model = model_instance(args.model_name, args.num_classes)
-    else:
-        raise 'Model {} not available'.format(args.arch)
+    model_generator = get_generator(arch)
+    model = model_generator(args.model_name, num_classes=args.num_classes)
 
     return model
 
 
-def _get_model_instance(name):
+def get_generator(arch):
     return {
         'resnet': resnet,
         'squeezenet': squeezenet,
@@ -46,4 +26,21 @@ def _get_model_instance(name):
         'resnet1d': resnet1d,
         'resnet1d_v2': resnet1d_v2,
         'lstm': lstm
-    }[name]
+    }[arch]
+
+
+def get_arch_from_model(model_name):
+    return {
+        'cnn1d_3': 'cnn1d',
+        'lenet5': 'lenet',
+        'lstm_1': 'lstm',
+        'resnet18': 'resnet',
+        'resnet34': 'resnet',
+        'resnet50': 'resnet',
+        'resnet1d_v2_18': 'resnet1d_v2',
+        'resnet1d_v2_10': 'resnet1d_v2',
+        'resnet1d_18': 'resnet1d',
+        'resnet1d_18': 'resnet1d',
+        'squeezenet1_0': 'squeezenet',
+        'squeezenet1_1': 'squeezenet'
+    }[model_name]

--- a/models/cnn1d.py
+++ b/models/cnn1d.py
@@ -39,7 +39,7 @@ def cnn1d_3(**kwargs):
     return model
 
 
-def cnn1d(model_name, num_classes, input_channels, pretrained=False):
+def cnn1d(model_name, num_classes):
     return{
-        'cnn1d_3': cnn1d_3(num_classes=num_classes, input_channels=input_channels),
+        'cnn1d_3': cnn1d_3(num_classes=num_classes, input_channels=1),
     }[model_name]

--- a/models/lenet.py
+++ b/models/lenet.py
@@ -36,7 +36,7 @@ def lenet5(**kwargs):
     return model
 
 
-def lenet(model_name, num_classes, input_channels, pretrained=False):
+def lenet(model_name, num_classes, **kwargs):
     return{
-        'lenet5': lenet5(num_classes=num_classes, input_channels=input_channels),
+        'lenet5': lenet5(num_classes=num_classes, input_channels=1),
     }[model_name]

--- a/models/lstm.py
+++ b/models/lstm.py
@@ -50,7 +50,7 @@ def lstm_1(**kwargs):
     return model
 
 
-def lstm(model_name, num_classes, pretrained=False):
+def lstm(model_name, num_classes, **kwargs):
     return{
         'lstm_1': lstm_1(num_classes=num_classes),
     }[model_name]

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -192,9 +192,9 @@ def resnet50(pretrained=False, **kwargs):
     return model
 
 
-def resnet(model_name, num_classes, input_channels, pretrained=False):
+def resnet(model_name, num_classes, **kwargs):
     return{
-        'resnet18': resnet18(num_classes=num_classes, input_channels=input_channels, pretrained=pretrained),
-        'resnet34': resnet34(num_classes=num_classes, input_channels=input_channels, pretrained=pretrained),
-        'resnet50': resnet50(num_classes=num_classes, input_channels=input_channels, pretrained=pretrained),
+        'resnet18': resnet18(num_classes=num_classes, input_channels=1, pretrained=False),
+        'resnet34': resnet34(num_classes=num_classes, input_channels=1, pretrained=False),
+        'resnet50': resnet50(num_classes=num_classes, input_channels=1, pretrained=False),
     }[model_name]

--- a/models/resnet1d.py
+++ b/models/resnet1d.py
@@ -105,8 +105,8 @@ def resnet1d_18(pretrained=False, **kwargs):
     return model
 
 
-def resnet1d(model_name, num_classes, input_channels, pretrained=False):
+def resnet1d(model_name, num_classes, **kwargs):
     return{
-        'resnet1d_18': resnet1d_18(num_classes=num_classes, input_channels=input_channels),
-        'resnet1d_10': resnet1d_10(num_classes=num_classes, input_channels=input_channels),
+        'resnet1d_18': resnet1d_18(num_classes=num_classes, input_channels=1),
+        'resnet1d_10': resnet1d_10(num_classes=num_classes, input_channels=1),
     }[model_name]

--- a/models/resnet1d_v2.py
+++ b/models/resnet1d_v2.py
@@ -105,8 +105,8 @@ def resnet1d_v2_18(pretrained=False, **kwargs):
     return model
 
 
-def resnet1d_v2(model_name, num_classes, input_channels, pretrained=False):
+def resnet1d_v2(model_name, num_classes, **kwargs):
     return{
-        'resnet1d_v2_18': resnet1d_v2_18(num_classes=num_classes, input_channels=input_channels),
-        'resnet1d_v2_10': resnet1d_v2_10(num_classes=num_classes, input_channels=input_channels),
+        'resnet1d_v2_18': resnet1d_v2_18(num_classes=num_classes, input_channels=1),
+        'resnet1d_v2_10': resnet1d_v2_10(num_classes=num_classes, input_channels=1),
     }[model_name]

--- a/models/squeezenet.py
+++ b/models/squeezenet.py
@@ -136,8 +136,8 @@ def squeezenet1_1(pretrained=False, **kwargs):
     return model
 
 
-def squeezenet(model_name, num_classes, input_channels, pretrained=False):
+def squeezenet(model_name, num_classes, **kwargs):
     return{
-        'squeezenet1_0': squeezenet1_0(num_classes=num_classes, input_channels=input_channels, pretrained=pretrained),
-        'squeezenet1_1': squeezenet1_1(num_classes=num_classes, input_channels=input_channels, pretrained=pretrained),
+        'squeezenet1_0': squeezenet1_0(num_classes=num_classes, input_channels=1, pretrained=False),
+        'squeezenet1_1': squeezenet1_1(num_classes=num_classes, input_channels=1, pretrained=False),
     }[model_name]


### PR DESCRIPTION
- add sensible values for default arguments so that we don't have to pass them all the time
- remove `arch` argument and deduce it from `model_name`
- add parameters managing versions of the models
- remove `name` argument and deduce it from `model_name` and `version` params
- removed `input_channels` since it's always 1

models are named now: `ecg_<model_name>.<version>`